### PR TITLE
This commit removes the duplicate key in MagicNumberTypeHash.

### DIFF
--- a/lib/sixarm_ruby_magic_number_type/string.rb
+++ b/lib/sixarm_ruby_magic_number_type/string.rb
@@ -56,7 +56,7 @@ class String
     "\x1F\xA0" => :tar_file_using_lzh_compression,
     "PK\x03\x04" => :pkzip,
     "7Z\xBC\xAF\x27\x1C" => :seven_zip,
-    "MZ" => :dos_os2_windows_executable,
+    # "MZ" => :dos_os2_windows_executable,  # Duplicate to line 36 above, Ruby 2.2 gives a warning
     ".ELF" => :unix_elf,
     "\x99\x00" => :pgp_public_ring,
     "\x95\x01" => :pgp_security_ring,

--- a/sixarm_ruby_magic_number_type.gemspec
+++ b/sixarm_ruby_magic_number_type.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |s|
   s.author            = "SixArm"
   s.email             = "sixarm@sixarm.com"
   s.homepage          = "http://sixarm.com/"
-  s.signing_key       = '/home/sixarm/keys/certs/sixarm-rsa1024-x509-private.pem'
-  s.cert_chain        = ['/home/sixarm/keys/certs/sixarm-rsa1024-x509-public.pem']
+  #s.signing_key       = '/home/sixarm/keys/certs/sixarm-rsa1024-x509-private.pem'
+  #s.cert_chain        = ['/home/sixarm/keys/certs/sixarm-rsa1024-x509-public.pem']
 
   s.platform          = Gem::Platform::RUBY
   s.require_path      = 'lib'


### PR DESCRIPTION
"MZ" is defined twice, once on line 36 and again on line 59.
Ruby 2.2 gives a warning for this (prior versions did not).

This commit comments out the duplicate on line 59.
